### PR TITLE
Switch to key-based SSH auth, Typescript support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Ronald Ng "https://github.com/ronalddddd"
 
 # Install OpenSSH Server, Git, etc...
 RUN apt-get update -y && apt-get install -y openssh-server git curl
-
+# SSH run dir
+RUN mkdir /var/run/sshd
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,11 @@ RUN apt-get install -y zsh fonts-powerline
 RUN sh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 RUN chsh -s $(which zsh)
 
+# Kompose - convert and run docker compose files as k8s configurations
+RUN curl -L https://github.com/kubernetes/kompose/releases/download/v1.17.0/kompose-linux-amd64 -o kompose
+RUN chmod +x kompose
+RUN mv ./kompose /usr/local/bin/kompose
+
 # Start script
 ADD start.sh /root/.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,8 @@
 FROM ubuntu:18.04
 MAINTAINER Ronald Ng "https://github.com/ronalddddd"
 
-ARG SSH_PASSWORD
-ENV SSH_PASSWORD ${SSH_PASSWORD:-happymeal}
-
 # Install OpenSSH Server, Git, etc...
 RUN apt-get update -y && apt-get install -y openssh-server git curl
-
-# Setup SSH Password
-RUN mkdir /var/run/sshd
-RUN echo "root:$SSH_PASSWORD" | chpasswd
-RUN sed -i 's/\#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,9 +79,8 @@ RUN /root/.tmux/plugins/tpm/scripts/install_plugins.sh
 RUN apt-get install -y neofetch
 
 # zsh
-RUN apt-get install -y zsh
+RUN apt-get install -y zsh fonts-powerline
 RUN sh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
-RUN apt-get install fonts-powerline
 RUN chsh -s $(which zsh)
 
 # Start script

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG SSH_PASSWORD
 ENV SSH_PASSWORD ${SSH_PASSWORD:-happymeal}
 
 # Install OpenSSH Server, Git, etc...
-RUN apt-get update -y && apt-get install -y openssh-server git
+RUN apt-get update -y && apt-get install -y openssh-server git curl
 
 # Setup SSH Password
 RUN mkdir /var/run/sshd
@@ -77,6 +77,12 @@ RUN /root/.tmux/plugins/tpm/scripts/install_plugins.sh
 
 # neofetch - displays system info
 RUN apt-get install -y neofetch
+
+# zsh
+RUN apt-get install -y zsh
+RUN sh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+RUN apt-get install fonts-powerline
+RUN chsh -s $(which zsh)
 
 # Start script
 ADD start.sh /root/.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,18 +22,14 @@ RUN echo "export VISIBLE=now" >> /etc/profile
 RUN apt-get update
 RUN apt-get install -y build-essential
 RUN apt-get install -y wget
-RUN wget -qO- https://deb.nodesource.com/setup_8.x | bash -
+RUN wget -qO- https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install --yes nodejs
 ## Install TypeScript
 RUN npm install -g typescript
+## Install yarn
+RUN npm install -g yarn
 ## Eslint
 RUN npm install -g eslint
-
-# Install elixir
-RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && dpkg -i erlang-solutions_1.0_all.deb
-RUN apt-get update
-RUN apt-get install -y esl-erlang
-RUN apt-get install -y elixir
 
 # Project directory
 RUN mkdir /projects

--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
 # docker-dev-container
 
-A docker container with a vim development environment. 
+A containerized vim development environment. 
 
 ![Screenshot of vim running in a tmux session](./screenshot.jpeg)
+
+## Why?
+
+- vim is great :)
+- portable development environment, just mount your projects directory
+- great for pair programming: spin up a container, and `tmux a` into the same session! 
 
 ## Features
 
 - vim 8 customized with plugins and some other configured defaults (see [vimrc](./vimrc))
+- git
 - Mosh 
 - tmux with some light configurations (see [tmux](./tmux.conf))
-- Node.js and TypeScript
+- Node.js and TypeScript, eslint
 - Elixir
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -7,25 +7,40 @@ A containerized vim development environment.
 ## Why?
 
 - vim is great :)
-- portable development environment, just mount your projects directory
-- great for pair programming: spin up a container, and `tmux a` into the same session! 
+- Portable development environment, just mount your projects directory
+- Great for pair programming: spin up a container, and `tmux a` into the same session! 
 
 ## Features
 
 - vim 8 customized with plugins and some other configured defaults (see [vimrc](./vimrc))
-- git
-- Mosh 
+  - File Browser (NERDTree)
+  - File quick open (ctrlp)
+  - Multi-cursor (vim-multiple-cursors)
+  - Auto-format (vim-prettier)
+  - Auto-complete (YouCompleteMe)
+  - Syntax checking (syntastic)
+- Mosh - mobile shell eliminates ssh disconnects over unstable networks
 - tmux with some light configurations (see [tmux](./tmux.conf))
-- Node.js and TypeScript, eslint
-- Elixir
+- git
 
 ## Quick Start
+
+- Set environment variable `DEVELOPER_PUBLIC_KEY` with the public key you want to use to SSH into this container
+- Mount a project folder (so you don't lose your work :)
+- (optional) Mount a .ssh folder with required credentials
+  - `authorized_keys` file for logging in
+  - Private keys for accessing  remote repositories, amongst other things...
+- Expose SSH port
+- (optional) Expose Mosh port range (UDP 6000 to 6100)
+
+Example: 
 
 ```sh
 # Start the container
 docker run -d --name dev-env-one \
+  -e DEVELOPER_PUBLIC_KEY=xxxxxx \
   -v /path/to/projects:/projects \
-  -e SSH_PASSWORD="mypassword"   \
+  -v /path/to/ssh:/root/.ssh     \
   -p 1234:22                     \
   ronalddddd/dev-container
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A docker container with a vim development environment. 
 
-![Screenshot of vim running in a tmux session]
-(./screenshot.jpeg)
+![Screenshot of vim running in a tmux session](./screenshot.jpeg)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ ssh root@localhost -p 1234
 
 ## Connecting via Mosh
 
+```sh
+mosh root@localhost -p 6000 --ssh="ssh -p 1234"
+```
+
 - getting a mosh client: https://mosh.org/#getting
 - you need to expose one or more UDP ports in the 6000 to 6100 range for
   mosh clients to connect

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+mkdir -p /${HOME}/.ssh
 echo "${DEVELOPER_PUBLIC_KEY}" >> /${HOME}/.ssh/authorized_keys
 /usr/sbin/sshd -D
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-echo "root:$SSH_PASSWORD" | chpasswd
+echo "${DEVELOPER_PUBLIC_KEY}" >> /${HOME}/.ssh/authorized_keys
 /usr/sbin/sshd -D
 

--- a/vimrc
+++ b/vimrc
@@ -27,9 +27,13 @@ Plugin 'jiangmiao/auto-pairs'
 Plugin 'vim-syntastic/syntastic'
 Plugin 'Valloric/YouCompleteMe'
 
-" Elixir
-Plugin 'elixir-editors/vim-elixir'
-Plugin 'slashmili/alchemist.vim'
+" Linter
+Plugin 'w0rp/ale'
+
+" TypeScript
+Plugin 'leafgarland/typescript-vim'
+Plugin 'Quramy/tsuquyomi'
+Plugin 'Quramy/vim-js-pretty-template'
 
 " Themes and stuff
 Plugin 'joshdick/onedark.vim'

--- a/vimrc
+++ b/vimrc
@@ -64,6 +64,10 @@ filetype plugin indent on    " required
 " Encoding
 set encoding=utf-8
 
+" Cursor
+autocmd InsertEnter * set cul
+autocmd InsertLeave * set nocul
+
 " Line numbers
 set relativenumber
 set number

--- a/vimrc
+++ b/vimrc
@@ -10,35 +10,38 @@ call vundle#begin()
 " let Vundle manage Vundle, required
 Plugin 'VundleVim/Vundle.vim'
 
-" Fuzzy file-open command  TODO: doesn't work without ruby enabled vim
-"Plugin 'wincent/command-t'
-"
-" git wrapper
-Plugin 'tpope/vim-fugitive'
-
-" HTML shortcuts
-Plugin 'rstacruz/sparkup'
-
 " NERDTree file browser
 Plugin 'scrooloose/nerdtree'
+
+" Fuzzy file open/finder
+Plugin 'kien/ctrlp.vim'
+
+" git wrapper
+Plugin 'tpope/vim-fugitive'
 
 " Syntax and Auto-complete stuff
 Plugin 'jiangmiao/auto-pairs'
 Plugin 'vim-syntastic/syntastic'
 Plugin 'Valloric/YouCompleteMe'
 
-" Linter
-Plugin 'w0rp/ale'
-
-" TypeScript
-Plugin 'leafgarland/typescript-vim'
-Plugin 'Quramy/tsuquyomi'
-Plugin 'Quramy/vim-js-pretty-template'
-
 " Themes and stuff
 Plugin 'joshdick/onedark.vim'
 Plugin 'vim-airline/vim-airline'
 Plugin 'vim-airline/vim-airline-themes'
+
+" HTML shortcuts
+Plugin 'rstacruz/sparkup'
+
+" Prettier
+Plugin 'prettier/vim-prettier'
+
+" TypeScript
+" Syntax Highlighting
+Plugin 'leafgarland/typescript-vim'
+" Code completion, navigate, show where symbol is referenced, etc...
+Plugin 'Quramy/tsuquyomi'
+" Syntax Highlighting for template strings
+Plugin 'Quramy/vim-js-pretty-template'
 
 " All of your Plugins must be added before the following line
 call vundle#end()            " required
@@ -90,7 +93,7 @@ set background=dark
 colorscheme PaperColor
 let g:airline_theme='papercolor'
 
-" Syntatic
+" Syntastic
 set statusline+=%#warningmsg#
 set statusline+=%{SyntasticStatuslineFlag()}
 set statusline+=%*
@@ -101,5 +104,17 @@ let g:syntastic_check_on_wq = 0
 let g:syntastic_javascript_checkers = ['eslint']
 let g:syntastic_javascript_eslint_exe = 'eslint .'
 
-" NERDTree
-map <silent> <C-n> :NERDTreeToggle<CR>
+" Key Mappings
+" NERDTree Hotkey
+map <silent> <C-n> :NERDTreeFocus<CR>
+
+" Auto file reload
+" Triger `autoread` when files changes on disk
+" https://unix.stackexchange.com/questions/149209/refresh-changed-content-of-file-opened-in-vim/383044#383044
+" https://vi.stackexchange.com/questions/13692/prevent-focusgained-autocmd-running-in-command-line-editing-mode
+autocmd FocusGained,BufEnter,CursorHold,CursorHoldI * if mode() != 'c' | checktime | endif
+" Notification after file change
+" https://vi.stackexchange.com/questions/13091/autocmd-event-for-autoread
+autocmd FileChangedShellPost *
+  \ echohl WarningMsg | echo "File changed on disk. Buffer reloaded." | echohl None
+

--- a/vimrc
+++ b/vimrc
@@ -109,7 +109,7 @@ let g:syntastic_javascript_eslint_exe = 'eslint .'
 
 " Key Mappings
 " NERDTree Hotkey
-map <silent> <C-n> :NERDTreeFocus<CR>
+map <silent> <C-o> :NERDTreeFocus<CR>
 
 " Auto file reload
 " Triger `autoread` when files changes on disk

--- a/vimrc
+++ b/vimrc
@@ -16,6 +16,9 @@ Plugin 'scrooloose/nerdtree'
 " Fuzzy file open/finder
 Plugin 'kien/ctrlp.vim'
 
+" Multi-cursor
+Plugin 'terryma/vim-multiple-cursors'
+
 " git wrapper
 Plugin 'tpope/vim-fugitive'
 


### PR DESCRIPTION
- Switch to key-based SSH authentication (#1)
  - Usage: set env variable `DEVELOPER_PUBLIC_KEY`
  - Removed support for password auth
- Typescript support
- Removed elixir
- Misc enhancements to vim configs (see commits)